### PR TITLE
Use the correct HostVMAdapter

### DIFF
--- a/builder/hyperv/common/powershell/hyperv/hyperv.go
+++ b/builder/hyperv/common/powershell/hyperv/hyperv.go
@@ -32,7 +32,7 @@ type scriptOptions struct {
 func GetHostAdapterIpAddressForSwitch(switchName string) (string, error) {
 	var script = `
 param([string]$switchName, [int]$addressIndex)
-$HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName | Select-Object -First 1
+$HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName | Get-VMNetworkAdapterIsolation | Where-Object { $_.IsolationMode -eq "Vlan" }
 if ($HostVMAdapter){
   $HostNetAdapter = Get-NetAdapter -IncludeHidden | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
   if ($HostNetAdapter){


### PR DESCRIPTION
This change will select the correct `HostVMAdapter` when there are multiple associated with the specified switch (usually `Default Switch`).

This is done by filtering the adapter selected by using the one where `IsolationMode` is set to `Vlan`.

Closes #99 